### PR TITLE
feat: enable debugging of typescript source

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,9 @@
       "android",
       "ios"
     ]
+  },
+  "config": {
+    "ionic_bundler": "webpack",
+    "ionic_source_map_type": "#inline-source-map"
   }
 }


### PR DESCRIPTION
Right now if you want to debug the JS layer of the application, all you can do is look at a several 1000 line `main.js` file which is pretty unreasonable.

This PR adds allows debugging of the application's typescript files. Take a look at the screencast to see this in action. You will notice that source maps for dependencies are not working right now but we should be able to figure that out soon.

![ts-debugging](https://user-images.githubusercontent.com/8656188/40713099-2ecc1a78-63f7-11e8-9347-ba7ca6f602bd.gif)
