### PR TITLE
Cleanup plugins and versions

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -75,9 +75,9 @@
     <plugin name="cordova-plugin-ionic-webview" spec="^1.2.1" />
     <plugin name="cordova-plugin-inappbrowser" spec="^3.0.0" />
     <plugin name="cordova-plugin-sslcertificatechecker" spec="^5.1.0" />
-    <plugin name="cordova-plugin-aerogear-metrics" spec="@aerogear/cordova-plugin-aerogear-metrics@^0.4.0" />
-    <plugin name="cordova-plugin-aerogear-security" spec="@aerogear/cordova-plugin-aerogear-security@^0.4.0" />
-    <plugin name="cordova-plugin-aerogear-push" spec="@aerogear/cordova-plugin-aerogear-push@^0.4.0" />
+    <plugin name="@aerogear/cordova-plugin-aerogear-metrics" />
+    <plugin name="@aerogear/cordova-plugin-aerogear-security" />
+    <plugin name="@aerogear/cordova-plugin-aerogear-push" />
     <plugin name="cordova-plugin-secure-storage" spec="^2.6.8" />
     <plugin name="cordova-plugin-whitelist" spec="^1.3.3" />
     <plugin name="cordova-plugin-secure-key-store" spec="^1.5.5" />

--- a/package.json
+++ b/package.json
@@ -41,14 +41,8 @@
     "@ionic/storage": "2.1.3",
     "cordova-android": "7.1.0",
     "cordova-ios": "4.5.4",
-    "cordova-plugin-app-version": "^0.1.9",
-    "cordova-plugin-device": "^2.0.2",
     "cordova-plugin-inappbrowser": "^3.0.0",
     "cordova-plugin-ionic-webview": "^1.2.1",
-    "cordova-plugin-iroot": "^0.7.0",
-    "cordova-plugin-is-debug": "^1.0.0",
-    "cordova-plugin-pincheck": "0.0.5",
-    "cordova-plugin-privacyscreen": "^0.4.0",
     "cordova-plugin-secure-key-store": "^1.5.5",
     "cordova-plugin-secure-storage": "^2.6.8",
     "cordova-plugin-splashscreen": "^5.0.2",
@@ -59,7 +53,6 @@
     "ionic-angular": "3.9.2",
     "ionicons": "3.0.0",
     "phonegap-plugin-multidex": "^1.0.0",
-    "phonegap-plugin-push": "^2.2.3",
     "rxjs": "5.5.8",
     "sw-toolbox": "3.6.0",
     "zone.js": "0.8.26"
@@ -71,23 +64,17 @@
   "description": "An Ionic project",
   "cordova": {
     "plugins": {
-      "cordova-plugin-device": {},
       "cordova-plugin-ionic-webview": {},
       "cordova-plugin-splashscreen": {},
       "cordova-plugin-whitelist": {},
       "cordova-plugin-secure-key-store": {},
       "cordova-plugin-inappbrowser": {},
-      "cordova-plugin-pincheck": {},
       "cordova-plugin-statusbar": {},
-      "cordova-plugin-is-debug": {},
       "cordova-plugin-sslcertificatechecker": {},
-      "cordova-plugin-app-version": {},
-      "cordova-plugin-iroot": {},
       "cordova-plugin-secure-storage": {},
       "@aerogear/cordova-plugin-aerogear-metrics": {},
       "@aerogear/cordova-plugin-aerogear-security": {},
-      "@aerogear/cordova-plugin-aerogear-push": {},
-      "cordova-plugin-aerogear-push": {}
+      "@aerogear/cordova-plugin-aerogear-push": {}
     },
     "platforms": [
       "android",


### PR DESCRIPTION
## Motivation

Revert change and fix problems with tooling.
Introduces back changes from here: https://github.com/aerogear/cordova-showcase-template/pull/46

Worth to note that with this changes none of the package.json should be changed.

## Verify

Kill node_modules plugins and platforms folders. Run IOS/Android as per instruction in contribution guide. After this change package.json should not contain any new additional entries that break builds!