### PR TITLE
Remove push toast

### DIFF
--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -25,6 +25,5 @@ export class HomePage {
     console.debug(`Received push notification: ${notification.message}`);
     // Navigate to push page
     this.navCtrl.push(PushMessagesPage);
-    
   }
 }

--- a/src/pages/pushMessages/pushMessages.ts
+++ b/src/pages/pushMessages/pushMessages.ts
@@ -19,15 +19,10 @@ export class PushMessagesPage {
     this.push.unregister();
   }
 
-  buttonVisible() {
-    return PushService.registered;
-  }
-
   ionViewDidEnter(): void {
-    if (!this.buttonVisible()) {
+    if (!this.push.isRegistered()) {
           this.alert.showAlert(constants.pushAlertMessage, constants.featureNotConfigured, 
             constants.alertButtons, constants.showDocs, constants.pushDocsUrl);
-
     }
   }
 }

--- a/src/services/push.service.ts
+++ b/src/services/push.service.ts
@@ -78,4 +78,8 @@ export class PushService {
       this.emit(newNotification);
     });
   }
+
+  public isRegistered() {
+    return PushService.registered;
+  }
 }

--- a/src/services/push.service.ts
+++ b/src/services/push.service.ts
@@ -1,6 +1,5 @@
 import {Push, PushObject} from "@ionic-native/push";
 import {Injectable} from "@angular/core";
-import {SimpleToastService} from "./toast.service";
 import { PushRegistration } from "@aerogear/push";
 import {PushMessage} from "../pages/pushMessages/message";
 
@@ -20,7 +19,7 @@ export class PushService {
 
   public messages: PushMessage[] = [];
 
-  constructor(private toast: SimpleToastService) {
+  constructor() {
   }
 
   public initPush() {
@@ -49,10 +48,9 @@ export class PushService {
   public unregister() {
     PushService.pushObject.unregister().then(() => {
       PushService.registered = false;
-
-      this.toast.showSuccess("Successfully unregistered");
+      console.log("Successfully unregistered");
     }).catch(() => {
-      this.toast.showError("Error unregistering");
+      console.log("Error unregistering");
     });
   }
 
@@ -65,9 +63,9 @@ export class PushService {
     PushService.pushObject.on('registration').subscribe(data => {
       new PushRegistration().register(data.registrationId, PUSH_ALIAS).then(() => {
         PushService.registered = true;
-        this.toast.showSuccess("Push registration successful", "bottom");
+        console.log("Push registration successful");
       }).catch(err => {
-        this.toast.showError(err.message, "bottom");
+        console.log(err.message);
       });
     });
 
@@ -76,7 +74,6 @@ export class PushService {
         message: notification.message,
         received: new Date().toDateString()
       };
-
       this.messages.push(newNotification);
       this.emit(newNotification);
     });


### PR DESCRIPTION
## Motivation

Currently, when the app loads a toast is shown on the home page informing the user if the push service has successfully l registered or if there was an error. 
This behavior does not happen in other showcase applications, so this change removes the toast and replaces them as a console log to allow for easy debugging of the push messages example.
