### PR TITLE
AEROGEAR-3325 - Push messages wont show fix

### DIFF
--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -23,11 +23,8 @@ export class HomePage {
 
   addNotification(notification: PushMessage) {
     console.debug(`Received push notification: ${notification.message}`);
-    const currentPage = this.navCtrl.getActive(true).name;
-
-    // Navigate to push page only if we aren't already there
-    if (PushMessagesPage.name !== currentPage) {
-      this.navCtrl.push(PushMessagesPage);
-    }
+    // Navigate to push page
+    this.navCtrl.push(PushMessagesPage);
+    
   }
 }

--- a/src/pages/pushMessages/pushMessages.html
+++ b/src/pages/pushMessages/pushMessages.html
@@ -7,11 +7,8 @@
   </ion-navbar>
 </ion-header>
 
-<ion-content>
-  <ion-refresher (ionRefresh)="doRefresh($event)">
-    <ion-refresher-content pullingText="Swipe down to refresh"></ion-refresher-content>
-  </ion-refresher>
-  <ion-grid class="aerogear-background-two" style="height: 100%">
+<ion-content class="aerogear-background-two">
+  <ion-grid>
     <ion-row *ngFor="let item of messages">
       <ion-card>
         <ion-card-content>

--- a/src/pages/pushMessages/pushMessages.ts
+++ b/src/pages/pushMessages/pushMessages.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { PushMessage } from "./message";
 import { PushService } from "../../services/push.service";
-import { Refresher } from "ionic-angular";
 import { constants } from '../../constants/constants';
 import { AlertService } from '../../services/alert.service';
 
@@ -18,11 +17,6 @@ export class PushMessagesPage {
 
   disablePush() {
     this.push.unregister();
-  }
-
-  doRefresh(refresher: Refresher) {
-    this.messages = this.push.messages;
-    refresher.complete();
   }
 
   buttonVisible() {


### PR DESCRIPTION
## Motivation

<!-- The reason underlying the contents of the PR, can be a link to the originating JIRA -->

JIRA: https://issues.jboss.org/browse/AEROGEAR-3325

## Description

The first implementation of the push message would only redirect to the push page if the user was not on the push message page. If the user was on the push page they would have to manually refresh the page,
This change refreshes or redirects to the push message page on every new message

## Verify

- Run the app
- Send the push notification from UPS admin UI (app should redirect to push message page)
- Send another push notification from UPS admin UI (new message should be visible on push page)