### PR TITLE
AEROGEAR-3332 - Cordova build errors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,16 +23,21 @@ To build the showcase app, run:
 npm install
 npm run ionic:build
 ```
-You can choose to run the application in either an emulator or a browser.
+You can choose to run the application on android or ios.
 ```
-npm run ionic:serve // to run a browser
+npm run ionic:android // to run in an android
 
-npm run ionic:android // to run in an android emulator
-
-npm run ionic:ios // to run in an ios emulator
+npm run ionic:ios // to run in an ios
 ```
 
-Note: If after running the application for iOS you get the following error: 
+==== Troubleshooting
+When running the application on both android or ios you will need to clean the projects root directory to remove conflicting files specific to each platform
+This can be done by running the following:
+```
+npm run clean
+```
+
+If after running the application for iOS you get the following error: 
 ```
 ld: library not found for -lGoogleToolboxForMac
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
@@ -47,3 +52,6 @@ and then re build the application.
 
 ==== Development and Contributing
 Looking to use the showcase for development purposes with the SDK please take some time to read the link:./CONTRIBUTING.md[General Contributing Guide]
+
+
+

--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,14 @@ As this application showcases features from link:https://github.com/aerogear/aer
 === Running the App
 This application can be run as a showcase using a published version of the AeroGear Js SDK, or as a development aid to working on the SDK.
 
+==== Prerequisites
+
+Ensure you have the following installed in your machine:
+
+- link:https://nodejs.org/en/[Node] - version 8.9.4
+- link:https://ionicframework.com/[Ionic] - version 3.20.0
+- link:https://cordova.apache.org/[Cordova] - version 8.0.0
+
 ==== Run Showcase
 The `master` branch will always track to the latest release of the SDK.
 

--- a/README.adoc
+++ b/README.adoc
@@ -15,14 +15,6 @@ As this application showcases features from link:https://github.com/aerogear/aer
 === Running the App
 This application can be run as a showcase using a published version of the AeroGear Js SDK, or as a development aid to working on the SDK.
 
-==== Prerequisites
-
-Ensure you have the following installed in your machine:
-
-- link:https://nodejs.org/en/[Node] - version 8.9.4
-- link:https://ionicframework.com/[Ionic] - version 3.20.0
-- link:https://cordova.apache.org/[Cordova] - version 8.0.0
-
 ==== Run Showcase
 The `master` branch will always track to the latest release of the SDK.
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "homepage": "http://aerogear.org/",
   "private": true,
   "scripts": {
-    "clean": "ionic-app-scripts clean",
+    "clean": "rm -rf platforms && rm -rf plugins && rm -rf node_modules && rm -rf www",
     "build": "ionic-app-scripts build",
     "lint": "ionic-app-scripts lint",
+    "ionic:clean": "ionic-app-scripts clean",
     "ionic:build": "ionic-app-scripts build",
     "ionic:serve": "ionic-app-scripts serve",
     "ionic:android": "ionic cordova run android",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,18 @@
     "ionic:build": "ionic-app-scripts build",
     "ionic:serve": "ionic-app-scripts serve",
     "ionic:android": "ionic cordova run android",
-    "ionic:ios": "ionic cordova run ios",
+    "ionic:ios": "ionic cordova platform add ios && cd platforms/ios && pod install && cd ../.. && ionic cordova run ios",
     "linkDev": "npm link @aerogear/app @aerogear/auth @aerogear/security @aerogear/core @aerogear/push"
+  },
+  "engines": {
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
   },
   "dependencies": {
     "@aerogear/app": "^1.0.0-alpha",
     "@aerogear/auth": "^1.0.0-alpha",
     "@aerogear/cordova-plugin-aerogear-metrics": "^1.0.0-alpha",
-    "@aerogear/cordova-plugin-aerogear-push": "^1.0.0-alpha",
+    "@aerogear/cordova-plugin-aerogear-push": "^1.0.0-dev-3",
     "@aerogear/cordova-plugin-aerogear-security": "^1.0.0-alpha",
     "@aerogear/core": "^1.0.0-alpha",
     "@aerogear/push": "^1.0.0-alpha",
@@ -62,6 +66,8 @@
   },
   "devDependencies": {
     "@ionic/app-scripts": "3.1.8",
+    "cordova": "^8.0.0",
+    "ionic": "^3.20.0",
     "typescript": "~2.6.2"
   },
   "description": "An Ionic project",


### PR DESCRIPTION
## Motivation

<!-- The reason underlying the contents of the PR, can be a link to the originating JIRA -->

JIRA: https://issues.jboss.org/browse/AEROGEAR-3327

## Description

Currently, we cannot build Cordova showcase App if it was previously built for a different platform, this appears to be down to conflicting files which are specific to each platform.
This change adds a clean script to be run between different platform builds along with an update to the documentation and build steps.

## Progress

- [x] Add Script
- [x] Update Docs

## Verification Steps

- From a clean project run `npm run ionic:android`
- Once built, run `npm run clean`
- Next run `npm run ionic:ios`
(Both builds should complete successfully.
