### PR TITLE
fixed displaying an alert in deviceTrust page twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ demos/src/**/*.css.shim.ts
 
 platforms/
 plugins/
+typings/*

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -81,9 +81,8 @@ export class MyApp {
   openPage(page) {
     // Reset the content nav to have just this page
     // we wouldn't want the back button to show in this scenario
-    this.menuCtrl.close().then(() => {
+    this.menuCtrl.close().then(() => {  
       this.nav.push(page.component, { 'linkParam' : page.param })
-      this.nav.setRoot(page.component);
     })
   }
 }

--- a/src/pages/deviceTrust/deviceTrust.ts
+++ b/src/pages/deviceTrust/deviceTrust.ts
@@ -119,7 +119,9 @@ export class DeviceTrustPage {
     this.totalTests = 0;
     this.totalDetections = 0;
     this.totalPassed= 0;
-    this.performChecks().then(() => { this.checkDialog(this.trustScore) });
+    this.performChecks().then(() => { 
+      this.checkDialog(this.trustScore);
+    });
     this.performChecksAndPublishMetrics();
   }
 


### PR DESCRIPTION
## Motivation

Before the fix, when opening the deviceTrust page with the trust score determined to be below the threshold, an alert was displayed twice.

JIRA: https://issues.jboss.org/browse/AEROGEAR-3361

## Description

Because of usage of Ionic navController, the Ionic lifecycle hooks are triggered twice per page, which caused an alert to be displayed twice too. Interrogating the stack of the navController and disabling the second attempt to call the methods triggered on the page load have fixed the problem

## Progress

- [x] Done Task