### PR TITLE
Menu fix

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -82,7 +82,7 @@ export class MyApp {
     // Reset the content nav to have just this page
     // we wouldn't want the back button to show in this scenario
     this.menuCtrl.close().then(() => {  
-      this.nav.push(page.component, { 'linkParam' : page.param })
+      this.nav.setRoot(page.component, { 'linkParam' : page.param });
     })
   }
 }


### PR DESCRIPTION
## Motivation

Currently, we lose the hamburger menu icon on a load of a new page, this change reverts back to using ` `setRoot` to fix the problem

## Verify Steps
- Open app
- Click through pages (hamburger menu icon should always be visible)
- Click on documentation links (clarify the correct urls are used)
