### PR TITLE
fixed not closing page with no services configured

### DIFF
--- a/src/services/alert.service.ts
+++ b/src/services/alert.service.ts
@@ -1,12 +1,14 @@
 import { Dialogs } from '@ionic-native/dialogs';
 import {Injectable} from "@angular/core";
 import { constants } from '../constants/constants';
+import { App } from 'ionic-angular';
+import { HomePage } from '../pages/home/home';
 
 declare var navigator: any;
 @Injectable()
 export class AlertService {
 
-    constructor(private dialogs: Dialogs) {
+    constructor(private dialogs: Dialogs, protected app: App) {
 
     }
 
@@ -20,7 +22,14 @@ export class AlertService {
                     if (action === constants.exitApp) {
                         navigator.app.exitApp();
                     } else if (action === constants.showDocs) {
+                      let hideFooterTimeout = setTimeout( () => {
+                        this.app.getActiveNav().setRoot(HomePage);
+                      }, 2000);
                         window.open(url, '_system');
+                    }
+                } else {
+                    if (action === constants.showDocs) {
+                        this.app.getActiveNav().setRoot(HomePage);
                     }
                 }
             });


### PR DESCRIPTION
## Motivation

Close page with corresponding services not configured

## Description

When there are no services configures, the page should be closed after dismissing the alert. Due to current navigation implementation, the "home" page is displayed

## Verification

remove a service configuration from mobile-services.json and go to the service's page and dismiss the alert

## Progress

- [x] Done Task