### PR TITLE
WIP Aerogear 3296

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -74,7 +74,6 @@
     </platform>
     <plugin name="cordova-plugin-splashscreen" spec="^5.0.2" />
     <plugin name="cordova-plugin-ionic-webview" spec="^1.2.1" />
-    <plugin name="cordova-plugin-inappbrowser" spec="^3.0.0" />
     <plugin name="cordova-plugin-sslcertificatechecker" spec="^5.1.0" />
     <plugin name="@aerogear/cordova-plugin-aerogear-metrics" />
     <plugin name="@aerogear/cordova-plugin-aerogear-security" />
@@ -83,6 +82,10 @@
     <plugin name="cordova-plugin-secure-key-store" spec="^1.5.5" />
     <plugin name="cordova-plugin-statusbar" spec="^2.4.2" />
     <plugin name="cordova-plugin-dialogs" spec="^2.0.1" />
-    <engine name="ios" spec="4.5.4" />
+    <plugin name="cordova-plugin-customurlscheme" spec="^4.3.0">
+        <variable name="URL_SCHEME" value="org.aerogear.js.showcase" />
+    </plugin>
+    <plugin name="cordova-plugin-inappbrowser" spec="^3.0.0" />
+    <engine name="ios" spec="~4.5.4" />
     <engine name="android" spec="~7.1.0" />
 </widget>

--- a/package.json
+++ b/package.json
@@ -47,9 +47,15 @@
     "@ionic/storage": "2.1.3",
     "cordova-android": "7.1.0",
     "cordova-ios": "4.5.4",
+    "cordova-plugin-app-version": "^0.1.9",
+    "cordova-plugin-customurlscheme": "^4.3.0",
+    "cordova-plugin-device": "^2.0.2",
     "cordova-plugin-dialogs": "^2.0.1",
     "cordova-plugin-inappbrowser": "^3.0.0",
     "cordova-plugin-ionic-webview": "^1.2.1",
+    "cordova-plugin-iroot": "^0.7.0",
+    "cordova-plugin-is-debug": "^1.0.0",
+    "cordova-plugin-pincheck": "0.0.6",
     "cordova-plugin-secure-key-store": "^1.5.5",
     "cordova-plugin-secure-storage": "^2.6.8",
     "cordova-plugin-splashscreen": "^5.0.2",
@@ -60,6 +66,7 @@
     "ionic-angular": "3.9.2",
     "ionic2-material-icons": "^1.0.3",
     "ionicons": "3.0.0",
+    "keycloak-js": "git://github.com/StephenCoady/keycloak-js-bower.git#master",
     "rxjs": "5.5.8",
     "sw-toolbox": "3.6.0",
     "zone.js": "0.8.26"
@@ -83,7 +90,16 @@
       "@aerogear/cordova-plugin-aerogear-metrics": {},
       "@aerogear/cordova-plugin-aerogear-security": {},
       "@aerogear/cordova-plugin-aerogear-push": {},
-      "cordova-plugin-dialogs": {}
+      "cordova-plugin-aerogear-push": {},
+      "cordova-plugin-dialogs": {},
+      "cordova-plugin-aerogear-metrics": {},
+      "cordova-plugin-aerogear-security": {},
+      "cordova-plugin-customurlscheme": {
+        "URL_SCHEME": "org.aerogear.js.showcase",
+        "ANDROID_SCHEME": " ",
+        "ANDROID_HOST": " ",
+        "ANDROID_PATHPREFIX": "/"
+      }
     },
     "platforms": [
       "android",

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -18,10 +18,17 @@ if (window['cordova']) {
  * This will reload angular context again
  */
 function initAuth() {
-  INSTANCE.init({}).then(() => {
+  window['handleOpenURL'] = function (url) {
+    if(url.indexOf("login") !== -1 ){
+      INSTANCE.continueLogin(url);
+    }
+    else if (url.indexOf("logout") !== -1) {
+      INSTANCE.continueLogout();
+    }
+  }
+  INSTANCE.init({ adapter: "default" }).then(() => {
     console.info("Initialized auth SDK")
   }).catch((err) => {
     console.error("Problem with auth init", err)
   });
 }
-

--- a/src/pages/auth/auth.ts
+++ b/src/pages/auth/auth.ts
@@ -12,6 +12,7 @@ import { AuthDetailsPage } from '../authDetails/authDetails';
 })
 export class AuthPage {
     authButtonState: boolean;
+    token: string;
 
     constructor(public toastCtrl: ToastController, private auth: Auth, public navCtrl: NavController, 
         public navParams: NavParams) {
@@ -22,8 +23,9 @@ export class AuthPage {
     }
 
     login() {
-        this.auth.login()
-            .then(() => this.navCtrl.setRoot(AuthDetailsPage));
+        this.auth.login({ redirectUri: "org.aerogear.js.showcase:/login"}).then(() => {
+            this.navCtrl.setRoot(AuthDetailsPage)
+        });
     }
 
     ionViewDidEnter(): void {

--- a/src/pages/authDetails/authDetails.ts
+++ b/src/pages/authDetails/authDetails.ts
@@ -22,8 +22,10 @@ export class AuthDetailsPage {
     }
 
     logout() {
-        this.auth.logout()
-            .then(() => this.navCtrl.setRoot(AuthPage));
+        this.auth.logout({ redirectUri: "org.aerogear.js.showcase:/logout" })
+            .then(() => {
+                this.navCtrl.setRoot(AuthPage);
+            });
         let toast = this.toastCtrl.create({
             message: 'Logged Out Successfully',
             duration: 3000,


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-3296

This PR fixes an issue where (in a development environment) it is currently not possible to login from a cordova app as the cordova adapter [here](https://github.com/keycloak/keycloak-js-bower/blob/master/dist/keycloak.js#L1289) always uses localhost.

**The Solution**
This PR, along with https://github.com/aerogear/aerogear-js-sdk/pull/136 solves this problem by:

1. Forcing the keycloak js adapter to use the "default" adapter.
2. Makes some changes to keycloak by making a function used by init publicly available
3. Handling the flow of login/logout slightly differently (due to the fact we now lose some context upon switching between the browser and the app)

The major drawback of this solution is that it requires us to have our own fork of the Keycloak JS adapter. This is because since we are using it in a way they don't prescribe the chances of us getting any changes merged upstream are slim. 

## Verification

1. Have a local mobile core with the keycloak running
2. Ensure org.aerogear.js.showcase:/logout and org.aerogear.js.showcase:/login are present in settings > valid redirect URIs for the client you are using.
3. Clone this PR and the linked SDK PR
4. Load the correct config into mobile-services.json of the app
5. Run the application and login/logout

**Expected Behaviour**

The application should open Keycloak in the system browser instead of the in app browser. The flow is as follows:

Login -> redirect to Keycloak -> *successfull auth* -> redirect back to application