### PR TITLE
 💄 make sure the push messages are readable

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -63,7 +63,6 @@ export class MyApp {
 
       { title: 'Push Notifications', component: PushPage, icon: 'notifications_active', param: 'Push Notifications' },
       { title: 'Documentation', component: DocumentationPage, icon: '', param: 'push' },
-      { title: 'Device Registration', component: DeviceRegistrationPage, icon: '', param: 'Device Registration' },
       { title: 'Push Messages', component: PushMessagesPage, icon: '', param: 'Push Messages' },
 
       { title: 'Metrics', component: MetricsPage, icon: 'insert_chart', param: 'Metrics' },

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -107,3 +107,7 @@ p{
 .push-info{
   color: var(--main-color);
 }
+
+.push-message {
+  color: #000000
+}

--- a/src/mobile-services.json
+++ b/src/mobile-services.json
@@ -36,7 +36,7 @@
       "config": {
         "ios": {
           "variantId": "70d8f761-cf64-485e-9606-b5bb88b4980d",
-          "variantSecret": "df19570a-36a4-4980-803f-9beec3dff020"
+          "variantSecret": "199c14c5-ed6a-4a92-92ae-423d8c7e1f43"
         },
         "android": {
           "variantId": "6fa16a51-aac1-40fc-a8d9-adcd7c0c27c2",

--- a/src/pages/pushMessages/pushMessages.html
+++ b/src/pages/pushMessages/pushMessages.html
@@ -12,7 +12,7 @@
     <ion-row *ngFor="let item of messages">
       <ion-card>
         <ion-card-content>
-          <h1>
+          <h1 class="push-message">
             {{ item.message }}
           </h1>
           <div class="push-info">


### PR DESCRIPTION
## Motivation

* There is a "Register Device" menu item
* The push messages are not readable because it's the same color as the backgroud

## Description

* Remove the "Register Device" menu
* Change the color of the push message to make sure it is readable.

## Progress

- [x] Done Task

See https://docs.google.com/presentation/d/1FZL-Wy5D_wUo5ADrfhpRBh-Ny2rGauI3_C8SBrlk6rw/edit#slide=id.g3c52d834c7_0_205