### PR TITLE
Update device check labels

### DIFF
--- a/src/pages/deviceTrust/deviceTrust.ts
+++ b/src/pages/deviceTrust/deviceTrust.ts
@@ -96,7 +96,7 @@ export class DeviceTrustPage {
   detectDeviceLock(): Promise<any> {
     return this.securityService.check(SecurityCheckType.hasDeviceLock)
       .then((deviceLockEnabled: SecurityCheckResult) => {
-        const deviceLockMsg = deviceLockEnabled.passed ? "Device Lock Detected" : "Device Lock Not Detected";
+        const deviceLockMsg = deviceLockEnabled.passed ? "Device Lock Enabled " : "No Device Lock Enabled";
         this.addDetection(deviceLockMsg, deviceLockEnabled.passed);
       });
   }


### PR DESCRIPTION
## Motivation

Based on feedback we had to update the label information for the device lock check to align with the Android Showcase App.

## Screenshot
![updated-trust](https://user-images.githubusercontent.com/14313111/41855512-bbb8382a-788a-11e8-9d7b-134e433248e7.png)
