### PR TITLE
Allow navigation to the documentation pages

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -5,6 +5,7 @@
     <author email="aerogear@googlegroups.com" href="https://aerogear.org/">AeroGear</author>
     <content src="index.html" />
     <access origin="*" />
+    <allow-navigation href="*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
     <allow-intent href="tel:*" />


### PR DESCRIPTION
Currently navigation to the documentation site on iOS is not allowed
because no allow-navigation setting is set. This adds an
allow-navigation option in config.xml.

![screen shot 2018-06-27 at 10 47 47](https://user-images.githubusercontent.com/8698527/41967101-be1d2ab6-79f8-11e8-8ccd-3b5d12a4f43c.png)
