### PR TITLE
Ensure submenu items are obvious to end user

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,9 +28,10 @@ import { PushRegistration } from '@aerogear/push';
 export class MyApp {
   @ViewChild(Nav) nav: Nav;
 
-  public pages: Array<{ title: string, component: any, icon: string, param: string }>;
+  public pages: Array<{ id: string, title: string, component: any, icon: string, param: string }>;
 
   rootPage: any = HomePage;
+  currentPage: any;
 
   constructor(public platform: Platform,
     public statusBar: StatusBar,
@@ -46,29 +47,30 @@ export class MyApp {
     this.pages = [];
     // used for an example of ngFor and navigation
     this.pages.push(
-      { title: 'Home', component: HomePage, icon: 'home', param: 'Home' },
+      { id: 'home', title: 'Home', component: HomePage, icon: 'home', param: 'Home' },
 
-      { title: 'Identity Management', component: IdentityManagementPage, icon: 'account_circle', param: 'Identity Management' },
-      { title: 'Documentation', component: DocumentationPage, icon: '', param: 'identity-management' },
-      { title: 'Authentication', component: AuthPage, icon: '', param: 'Authentication' },
-      { title: 'SSO', component: SSOPage, icon: '', param: 'SSO' },
+      { id: 'idm', title: 'Identity Management', component: IdentityManagementPage, icon: 'account_circle', param: 'Identity Management' },
+      { id: 'idm-docs', title: 'Documentation', component: DocumentationPage, icon: null, param: 'identity-management' },
+      { id: 'idm-auth', title: 'Authentication', component: AuthPage, icon: null, param: 'Authentication' },
+      { id: 'idm-sso', title: 'SSO', component: SSOPage, icon: null, param: 'SSO' },
 
-      { title: 'Device Security', component: DeviceSecurityPage, icon: 'security', param: 'Device Security' },
-      { title: 'Documentation', component: DocumentationPage, icon: '', param: 'device-security' },
-      { title: 'Device Trust', component: DeviceTrustPage, icon: '', param: 'Device Trust' },
-      { title: 'Secure Storage', component: StoragePage, icon: '', param: 'Secure Storage' },
-      { title: 'Cert Pinning', component: CertPinningPage, icon: '', param: 'Cert Pinning' },
+      { id: 'security', title: 'Device Security', component: DeviceSecurityPage, icon: 'security', param: 'Device Security' },
+      { id: 'security-docs', title: 'Documentation', component: DocumentationPage, icon: null, param: 'device-security' },
+      { id: 'security-trust', title: 'Device Trust', component: DeviceTrustPage, icon: null, param: 'Device Trust' },
+      { id: 'security-storage', title: 'Secure Storage', component: StoragePage, icon: null, param: 'Secure Storage' },
+      { id: 'security-pinning', title: 'Cert Pinning', component: CertPinningPage, icon: null, param: 'Cert Pinning' },
 
-      { title: 'Push Notifications', component: PushPage, icon: 'notifications_active', param: 'Push Notifications' },
-      { title: 'Documentation', component: DocumentationPage, icon: '', param: 'push' },
-      { title: 'Push Messages', component: PushMessagesPage, icon: '', param: 'Push Messages' },
+      { id: 'push', title: 'Push Notifications', component: PushPage, icon: 'notifications_active', param: 'Push Notifications' },
+      { id: 'push-docs', title: 'Documentation', component: DocumentationPage, icon: null, param: 'push' },
+      { id: 'push-messages', title: 'Push Messages', component: PushMessagesPage, icon: null, param: 'Push Messages' },
 
-      { title: 'Metrics', component: MetricsPage, icon: 'insert_chart', param: 'Metrics' },
-      { title: 'Documentation', component: DocumentationPage, icon: '', param: 'metrics' },
-      { title: 'Device Profile Info', component: DeviceProfilePage, icon: '', param: 'Device Profile Info' },
-      { title: 'Trust Check Info', component: TrustCheckPage, icon: '', param: 'Trust Check Info' }
+      { id: 'metrics', title: 'Metrics', component: MetricsPage, icon: 'insert_chart', param: 'Metrics' },
+      { id: 'metrics-docs', title: 'Documentation', component: DocumentationPage, icon: null, param: 'metrics' },
+      { id: 'metrics-profile', title: 'Device Profile Info', component: DeviceProfilePage, icon: null, param: 'Device Profile Info' },
+      { id: 'metrics-trust', title: 'Trust Check Info', component: TrustCheckPage, icon: null, param: 'Trust Check Info' }
 
     );
+    this.currentPage = this.pages[0];
   }
 
   initializeApp() {
@@ -82,6 +84,10 @@ export class MyApp {
     });
   }
 
+  isCurrentPage(page) {
+    return page.id === this.currentPage.id;
+  }
+
   openPage(page) {
     // Reset the content nav to have just this page
     // we wouldn't want the back button to show in this scenario
@@ -93,11 +99,12 @@ export class MyApp {
       }
 
       if (page.component === AuthPage && !this.auth.hasConfig()) {
-          this.alert.showAlert(constants.idmMessage, constants.featureNotConfigured,
-            constants.alertButtons, constants.showDocs, constants.idmUrl);
-          return;
+        this.alert.showAlert(constants.idmMessage, constants.featureNotConfigured,
+          constants.alertButtons, constants.showDocs, constants.idmUrl);
+        return;
       }
       this.nav.setRoot(page.component, { 'linkParam': page.param });
+      this.currentPage = page;
     })
   }
 }

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,35 +1,27 @@
 <ion-menu [content]="content">
-    <ion-header>
-        <ion-toolbar color=primary>
-            <ion-title>Menu</ion-title>
-        </ion-toolbar>
-    </ion-header>
 
     <ion-content>
-
-            <ion-item no-lines class="banner">
-                <ion-avatar item-start>
-                    <img src="./assets/imgs/ag-logo.png">
-                </ion-avatar>
-                <p class="banner">AeroGear</p>
-                <p class="banner">aerogear.org</p>
-            </ion-item>
+        <ion-item no-lines class="banner">
+            <ion-avatar item-start>
+                <img src="./assets/imgs/ag-logo.png">
+            </ion-avatar>
+            <p class="banner">AeroGear</p>
+            <p class="banner">aerogear.org</p>
+        </ion-item>
 
 
         <!--&lt;!&ndash; side menu content &ndash;&gt;-->
         <!--<side-menu-content [settings]="sideMenuSettings" [options]="pages" (change)="openPage($event)"></side-menu-content>-->
 
-      <ion-list>
-        <button menuClose ion-item detail-none *ngFor="let p of pages" (click)="openPage(p)">
-            <ion-icon item-start>
-                <i class="material-icons">{{p.icon}}</i>
-            </ion-icon>
-        <span>{{p.title}}</span>
-        </button>
-      </ion-list>
-
+        <ion-list no-lines>
+            <button menuClose ion-item detail-none *ngFor="let p of pages" (click)="openPage(p)" [ngClass]="{ 'navmenu-item': p.icon != null, 'navmenu-sub-item': p.icon === null, 'navmenu-active': isCurrentPage(p) }">
+                <ion-icon item-start>
+                    <i class="material-icons">{{p.icon}}</i>
+                </ion-icon>
+                <span>{{p.title}}</span>
+            </button>
+        </ion-list>
     </ion-content>
-
 </ion-menu>
 
 <!-- Disable swipe-to-go-back because it's poor UX to combine STGB with side menus -->

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -114,3 +114,13 @@ p{
 .push-message {
   color: #000000
 }
+
+.navmenu-sub-item {
+  font-size: 10pt;
+  padding-left: 26px;
+}
+
+.navmenu-active {
+  background-color: color($colors, lightgray, base);
+  color: color($colors, orange, base);
+}

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -41,6 +41,7 @@ $colors: (
   green:      #008000,
   red:        #D82B32,
   orange:     #e25027,
+  lightgray:  #CDCDCD
 );
 
 


### PR DESCRIPTION
This commit makes a few changes in order for the navigation menu
to appear as if it has submenu items.

* Add ids to each page so that they can be uniquely identified when
it comes to determining which one is active. This is important for
styling purposes.

* Remove the top Menu bar from the navmenu to match the other show
case applications.

* Add some styling for active and submenu items so that they are
more obvious to the end user.

* Format any touched files.