### PR TITLE
Documented how to run in the browser

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,11 +55,13 @@ To build the showcase app, run:
 npm install
 npm run ionic:build
 ```
-You can choose to run the application on android or ios.
+You can choose to run the application on android or ios or in the browser.
 ```
 npm run ionic:android // to run in an android
 
 npm run ionic:ios // to run in an ios
+
+npm run ionic:serve // to run in a browser
 ```
 
 ==== Troubleshooting


### PR DESCRIPTION
## Motivation

Added information on how to run the app in the browser. It is the simplest option so why not to document it. It is much easier especially if you don't have Android Emulator or iOS dev environment installed.